### PR TITLE
feat: migrate to Crann v2 with key-specific subscriptions

### DIFF
--- a/build.mjs
+++ b/build.mjs
@@ -2,7 +2,7 @@ import esbuild from 'esbuild';
 import chokidar from 'chokidar';
 import fs from 'fs';
 import path from 'path';
-import {exec} from 'child_process';
+import { exec } from 'child_process';
 
 const srcDir = './src';
 const distDir = './dist';
@@ -13,90 +13,105 @@ const args = process.argv.slice(2);
 const watchMode = args.includes('--watch') || args.includes('-w');
 
 const entryPoints = [
-    './src/scripts/content-script.ts',
-    './src/service-workers/service-worker.ts',
+  './src/scripts/content-script.ts',
+  './src/service-workers/service-worker.ts'
 ];
 const assets = ['./src/assets'];
 
 const build = () => {
-    ensureDirExists(distDir);
-    // Increment the minor version in manifest.json
-    const manifest = JSON.parse(fs.readFileSync(manifestPath, 'utf-8'));
-    let [major, minor, patch] = manifest.version.split('.').map(Number);
-    patch += 1;
-    manifest.version = `${major}.${minor}.${patch}`;
-    fs.writeFileSync(manifestPath, JSON.stringify(manifest, null, 2));
+  console.log('NODE_ENV:', JSON.stringify(process.env.NODE_ENV));
+  ensureDirExists(distDir);
+  // Increment the minor version in manifest.json
+  const manifest = JSON.parse(fs.readFileSync(manifestPath, 'utf-8'));
+  let [major, minor, patch] = manifest.version.split('.').map(Number);
+  patch += 1;
+  manifest.version = `${major}.${minor}.${patch}`;
+  fs.writeFileSync(manifestPath, JSON.stringify(manifest, null, 2));
 
-    esbuild.build({
-        entryPoints: entryPoints,
-        outdir: distDir,
-        bundle: true,
-        minify: true,
-        sourcemap: true,
-        format: 'esm'
-    }).catch(() => process.exit(1));
+  esbuild
+    .build({
+      entryPoints: entryPoints,
+      outdir: distDir,
+      bundle: true,
+      minify: true,
+      sourcemap: true,
+      format: 'esm',
+      define: {
+        'process.env.NODE_ENV': JSON.stringify(
+          process.env.NODE_ENV || 'production'
+        )
+      }
+    })
+    .catch(() => process.exit(1));
 
-    esbuild.build({
-        entryPoints: ['./src/ui/index.tsx'],
-        outfile: 'dist/ui/index.js',
-        bundle: true,
-        minify: true,
-        sourcemap: true,
-        target: ['chrome58', 'firefox57'],
-        loader: { '.ts': 'ts', '.tsx': 'tsx' },
-        define: {
-          'process.env.NODE_ENV': '"production"'
-        },
-    }).catch(() => process.exit(1));
+  esbuild
+    .build({
+      entryPoints: ['./src/ui/index.tsx'],
+      outfile: 'dist/ui/index.js',
+      bundle: true,
+      minify: true,
+      sourcemap: true,
+      target: ['chrome58', 'firefox57'],
+      loader: { '.ts': 'ts', '.tsx': 'tsx' },
+      define: {
+        'process.env.NODE_ENV': JSON.stringify(
+          process.env.NODE_ENV || 'production'
+        )
+      }
+    })
+    .catch(() => process.exit(1));
 
-    // Build settings page
-    esbuild.build({
-        entryPoints: ['./src/settings/index.tsx'],
-        outfile: 'dist/settings/index.js',
-        bundle: true,
-        minify: true,
-        sourcemap: true,
-        target: ['chrome58', 'firefox57'],
-        loader: { '.ts': 'ts', '.tsx': 'tsx' },
-        define: {
-          'process.env.NODE_ENV': '"production"'
-        },
-        alias: {
-          '@': './src',
-          '@ui': './src/ui',
-          '@features': './src/ui/features',
-          '@utils': './src/ui/utils',
-        },
-    }).catch(() => process.exit(1));
+  // Build settings page
+  esbuild
+    .build({
+      entryPoints: ['./src/settings/index.tsx'],
+      outfile: 'dist/settings/index.js',
+      bundle: true,
+      minify: true,
+      sourcemap: true,
+      target: ['chrome58', 'firefox57'],
+      loader: { '.ts': 'ts', '.tsx': 'tsx' },
+      define: {
+        'process.env.NODE_ENV': JSON.stringify(
+          process.env.NODE_ENV || 'production'
+        )
+      },
+      alias: {
+        '@': './src',
+        '@ui': './src/ui',
+        '@features': './src/ui/features',
+        '@utils': './src/ui/utils'
+      }
+    })
+    .catch(() => process.exit(1));
 
-    // Copy assets
-    assets.forEach(assetDir => {
-        fs.readdirSync(assetDir).forEach(file => {
-            const srcPath = path.join(assetDir, file);
-            const destPath = path.join(distDir, file);
-            copyRecursiveSync(srcPath, destPath);
-        });
+  // Copy assets
+  assets.forEach((assetDir) => {
+    fs.readdirSync(assetDir).forEach((file) => {
+      const srcPath = path.join(assetDir, file);
+      const destPath = path.join(distDir, file);
+      copyRecursiveSync(srcPath, destPath);
     });
+  });
 
-    // Copy HTML and CSS from root src to dist
-    fs.readdirSync(srcDir).forEach(file => {
-        if (file.endsWith('.html') || file.endsWith('.css')) {
-            fs.copyFileSync(`${srcDir}/${file}`, `${distDir}/${file}`);
-        }
-    });
+  // Copy HTML and CSS from root src to dist
+  fs.readdirSync(srcDir).forEach((file) => {
+    if (file.endsWith('.html') || file.endsWith('.css')) {
+      fs.copyFileSync(`${srcDir}/${file}`, `${distDir}/${file}`);
+    }
+  });
 
+  // Copy settings assets
+  const settingsDir = './src/settings';
+  ensureDirExists(path.join(distDir, 'settings'));
+  fs.readdirSync(settingsDir).forEach((file) => {
+    if (file.endsWith('.html')) {
+      fs.copyFileSync(`${settingsDir}/${file}`, `${distDir}/settings/${file}`);
+    }
+  });
 
-    // Copy settings assets
-    const settingsDir = './src/settings';
-    ensureDirExists(path.join(distDir, 'settings'));
-    fs.readdirSync(settingsDir).forEach(file => {
-        if (file.endsWith('.html')) {
-            fs.copyFileSync(`${settingsDir}/${file}`, `${distDir}/settings/${file}`);
-        }
-    });
-
-    //triggerKeyboardMaestroMacro();
-    copyManifest();
+  //triggerKeyboardMaestroMacro();
+  copyManifest();
 };
 
 // Initial build
@@ -104,60 +119,59 @@ build();
 
 // Watch for file changes in src directory (only in watch mode)
 if (watchMode) {
-    console.log('Watching for changes...');
-    chokidar.watch(srcDir).on('change', (event, path) => {
-        console.log(`Rebuilding => File ${event} has been changed`);
-        build();
-    });
+  console.log('Watching for changes...');
+  chokidar.watch(srcDir).on('change', (event, path) => {
+    console.log(`Rebuilding => File ${event} has been changed`);
+    build();
+  });
 } else {
-    console.log('Build complete.');
+  console.log('Build complete.');
 }
-
 
 // Function to ensure directory exists
 function ensureDirExists(dir) {
-    if (!fs.existsSync(dir)) {
-        fs.mkdirSync(dir, { recursive: true });
-    }
-};
+  if (!fs.existsSync(dir)) {
+    fs.mkdirSync(dir, { recursive: true });
+  }
+}
 
 function copyRecursiveSync(src, dest) {
-    const exists = fs.existsSync(src);
-    const stats = exists && fs.statSync(src);
-    const isDirectory = exists && stats.isDirectory();
-    if (isDirectory) {
-        fs.mkdirSync(dest, { recursive: true });
-        fs.readdirSync(src).forEach(childItemName => {
-            copyRecursiveSync(path.join(src, childItemName),
-                              path.join(dest, childItemName));
-        });
-    } else {
-        fs.copyFileSync(src, dest);
-    }
-};
+  const exists = fs.existsSync(src);
+  const stats = exists && fs.statSync(src);
+  const isDirectory = exists && stats.isDirectory();
+  if (isDirectory) {
+    fs.mkdirSync(dest, { recursive: true });
+    fs.readdirSync(src).forEach((childItemName) => {
+      copyRecursiveSync(
+        path.join(src, childItemName),
+        path.join(dest, childItemName)
+      );
+    });
+  } else {
+    fs.copyFileSync(src, dest);
+  }
+}
 
 function copyManifest() {
-    const destManifestPath = path.join(distDir, 'manifest.json');
-    fs.copyFileSync(manifestPath, destManifestPath);
-};
-
+  const destManifestPath = path.join(distDir, 'manifest.json');
+  fs.copyFileSync(manifestPath, destManifestPath);
+}
 
 function triggerKeyboardMaestroMacro() {
-    const script = `
+  const script = `
         tell application "Keyboard Maestro Engine"
             do script "52E810AA-4A52-4E4F-8244-D75FD150D49B"
         end tell
     `;
-    exec(`osascript -e '${script}'`, (err, stdout, stderr) => {
-        if (err) {
-            console.error(err);
-            return;
-        }
-        if (stderr) {
-            console.error(stderr);
-            return;
-        }
-        console.log(stdout);
-    });
+  exec(`osascript -e '${script}'`, (err, stdout, stderr) => {
+    if (err) {
+      console.error(err);
+      return;
+    }
+    if (stderr) {
+      console.error(stderr);
+      return;
+    }
+    console.log(stdout);
+  });
 }
-

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Lensor",
-  "version": "1.1.10",
+  "version": "1.1.35",
   "description": "A magnifying lens for pixel-perfect color detection and palette generation",
   "permissions": [
     "activeTab",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,18 +1,18 @@
 {
   "name": "lensor",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "lensor",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "license": "MIT",
       "dependencies": {
         "@spissvinkel/simplex-noise": "^1.0.1",
         "@types/node": "^20.12.12",
         "chokidar": "^3.5.3",
-        "crann": "^1.0.45",
+        "crann": "^2.0.6",
         "debug": "^4.4.3",
         "esbuild": "^0.19.9",
         "fisheyegl": "^0.1.2",
@@ -1525,14 +1525,37 @@
       "license": "MIT"
     },
     "node_modules/crann": {
-      "version": "1.0.45",
-      "resolved": "https://registry.npmjs.org/crann/-/crann-1.0.45.tgz",
-      "integrity": "sha512-q3DLfSMGIjSwqEI3r8XS0kjNvSyUHeiisJdmcaOJUWnwFz/SV2MpgAWKfA2yLG9IuGZOU3W3hN5ocxV+7S861g==",
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/crann/-/crann-2.0.6.tgz",
+      "integrity": "sha512-ja7nj3G66kfLJqmtAYiUJjaoaEAhhmCSWe2fP53kwrog4q7eoA9MJ+NusIc2LbkWpiWtcxOV+rjPlKBPYLpAGw==",
       "license": "ISC",
+      "dependencies": {
+        "uuid": "^13.0.0"
+      },
       "peerDependencies": {
-        "porter-source": "^1.1.22",
         "react": ">=16.8.0",
         "react-dom": ">=16.8.0"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/crann/node_modules/uuid": {
+      "version": "13.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-13.0.0.tgz",
+      "integrity": "sha512-XQegIaBTVUjSHliKqcnFqYypAd4S+WCYt5NIeRs6w/UAry7z8Y9j5ZwRRL4kzq9U3sD6v+85er9FvkEaBpji2w==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist-node/bin/uuid"
       }
     },
     "node_modules/cross-spawn": {

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "@spissvinkel/simplex-noise": "^1.0.1",
     "@types/node": "^20.12.12",
     "chokidar": "^3.5.3",
-    "crann": "^1.0.45",
+    "crann": "^2.0.6",
     "debug": "^4.4.3",
     "esbuild": "^0.19.9",
     "fisheyegl": "^0.1.2",

--- a/src/ui/features/CaptureFlash/CaptureFlash.tsx
+++ b/src/ui/features/CaptureFlash/CaptureFlash.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useState, useRef } from 'react';
 import styled, { keyframes, css } from 'styled-components';
-import { useLensorState } from '../../hooks/useLensorState';
+import { useCrannState } from '../../hooks/useLensorState';
 import { useSettings } from '../../../settings/useSettings';
 
 const CANVAS_SIZE = 400;
@@ -130,9 +130,8 @@ const InnerPulse = styled.div<PulseRingProps>`
  * before the actual screenshot is taken, avoiding the flash appearing in the capture.
  */
 const CaptureFlash: React.FC = () => {
-  const { useStateItem } = useLensorState();
-  const [isFlashing] = useStateItem('isFlashing');
-  const [lensePosition] = useStateItem('lensePosition');
+  const [isFlashing] = useCrannState('isFlashing');
+  const [lensePosition] = useCrannState('lensePosition');
   const { settings } = useSettings();
   
   const [isAnimating, setIsAnimating] = useState(false);

--- a/src/ui/hooks/useLenseCanvasUpdate.ts
+++ b/src/ui/hooks/useLenseCanvasUpdate.ts
@@ -1,7 +1,5 @@
-import { useState, useCallback, useRef } from 'react';
+import { useCallback, useRef } from 'react';
 import FisheyeGl, { Fisheye } from '../../lib/fisheyegl';
-import { DebugInfoProps } from '../utils/debug-utils';
-import { useLensorState } from './useLensorState';
 import { debug } from '../../lib/debug';
 
 const log = debug.canvas;

--- a/src/ui/hooks/useLensorState.ts
+++ b/src/ui/hooks/useLensorState.ts
@@ -1,4 +1,31 @@
-import { createCrannStateHook } from 'crann';
-import { LensorStateConfig } from '../state-config';
+import { createCrannHooks } from 'crann/react';
+import { lensorConfig } from '../state-config';
 
-export const useLensorState = createCrannStateHook(LensorStateConfig);
+// Enable debug logging in development builds only
+const IS_DEV = process.env.NODE_ENV === 'development';
+
+/**
+ * Crann React hooks for Lensor state management.
+ *
+ * Usage:
+ *
+ * // Selector pattern - returns selected value, re-renders on change
+ * const count = useCrannState(s => s.zoom);
+ *
+ * // Key pattern - returns [value, setValue] tuple
+ * const [zoom, setZoom] = useCrannState('zoom');
+ *
+ * // Actions - stable references, won't cause re-renders
+ * const { captureTab } = useCrannActions();
+ * const dataUrl = await captureTab();
+ *
+ * // Check connection status
+ * const isReady = useCrannReady();
+ */
+export const {
+  useCrannState,
+  useCrannActions,
+  useCrannReady,
+  useAgent,
+  CrannProvider
+} = createCrannHooks(lensorConfig, { debug: IS_DEV });


### PR DESCRIPTION
## Summary
Migrates state synchronization from Crann v1 to v2 API with improved efficiency.

## Changes
- **Service Worker**: Refactored to use key-specific `store.subscribe()` calls instead of checking for changed keys in a single callback
  - `['active']` subscription for inactivity alarm management
  - `['initialized']` subscription for UI auto-activation
- **Lifecycle Listeners**: Commented out unused Chrome runtime lifecycle logging
- **UI & Hooks**: Updated for Crann v2 compatibility

## Benefits
- More efficient: callbacks only run when their specific keys change
- Cleaner code: no need for `'key' in changes` checks
- Better separation of concerns for different state changes